### PR TITLE
Update dependencies to allow upgrading to latest Rails 4.1 versions

### DIFF
--- a/rasputin.gemspec
+++ b/rasputin.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |s|
   s.description = %q{Ember.js for the Rails asset pipeline.}
 
   s.rubyforge_project = "rasputin"
-  s.add_runtime_dependency 'railties', '>= 3.1', '< 4.1'
-  s.add_runtime_dependency 'actionpack', '>= 3.1', '< 4.1'
-  s.add_runtime_dependency 'sprockets', '~> 2.0'
-  s.add_runtime_dependency 'jquery-rails', '< 2.1'
+  s.add_runtime_dependency 'railties', '>= 3.1', '< 4.2'
+  s.add_runtime_dependency 'actionpack', '>= 3.1', '< 4.2'
+  s.add_runtime_dependency 'sprockets', '~> 2.2'
+  s.add_runtime_dependency 'jquery-rails', '< 4.0'
 
   s.files         = `git ls-files`.split("\n")
   #s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/vendor/assets/javascripts/ember.js
+++ b/vendor/assets/javascripts/ember.js
@@ -11733,7 +11733,7 @@ Ember.ArrayController = Ember.ArrayProxy.extend();
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
-ember_assert("Ember requires jQuery 1.6 or 1.7", window.jQuery && window.jQuery().jquery.match(/^1\.[67](\.\d+)?(pre|rc\d?)?/));
+ember_assert("Ember requires jQuery", window.jQuery);
 Ember.$ = window.jQuery;
 
 })();


### PR DESCRIPTION
LeanKit card: https://emexpower.leankit.com/Boards/View/43641214/214235994

This work consists of 4 PR's: 
- EMEX - https://github.com/emex/emex/pull/2297
- Portal - https://github.com/emex/supplier_portal/pull/99
- Deal Sheet Service - https://github.com/emex/deal_sheet_service/pull/24
- Rasputin - https://github.com/emex/rasputin/pull/1

We need to upgrade EMEX and Portal's Rails versions, since the most recent versions include some security fixes.

EMEX should be bumped to Rails 3.2.22.

Portal should be bumped to 4.1.11. Although that's an upgrade in minor versions, it seems like the closest release that was announced. If you think it's worth upgrading to 4.2.2 though, go for it.

Deal Sheet Service needs Rack upgraded to version >= 1.5.4
