### PR TITLE
Upgrade to latest Rails 4 release

### DIFF
--- a/rasputin.gemspec
+++ b/rasputin.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |s|
   s.description = %q{Ember.js for the Rails asset pipeline.}
 
   s.rubyforge_project = "rasputin"
-  s.add_runtime_dependency 'railties', '>= 3.1', '< 4.2'
-  s.add_runtime_dependency 'actionpack', '>= 3.1', '< 4.2'
+  s.add_runtime_dependency 'railties', '~> 4.2'
+  s.add_runtime_dependency 'actionpack', '~> 4.2'
   s.add_runtime_dependency 'sprockets', '~> 2.2'
-  s.add_runtime_dependency 'jquery-rails', '< 4.0'
+  s.add_runtime_dependency 'jquery-rails'
 
   s.files         = `git ls-files`.split("\n")
   #s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Card: https://emexpower.leankit.com/Boards/View/43641214/295021877

Related PR: https://github.com/emex/emex/pull/2690

Note: Please base this off of the Partners work, if that's not merged in already.

This card covers moving the EMEX app to the latest Rails 4 release (not Rails 5, if it's released by now.)

I recommend working through the minor releases in steps:

http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-4-0-to-rails-4-1

http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-4-1-to-rails-4-2 

While does this work, if you see large changes that need to be made as part of fixing a deprecation warning, feel free to spin those off into separate cards. 

We will need a major QA effort before releasing this.
