### PR TITLE
Upgrade Portal to latest Rails version

### DIFF
--- a/lib/rasputin.rb
+++ b/lib/rasputin.rb
@@ -19,10 +19,10 @@ module Rasputin
     config.rasputin.use_javascript_require = true
     config.rasputin.strip_javascript_require = true
 
-    initializer :setup_rasputin, :group => :all do |app|
-      app.assets.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
-      app.assets.register_engine '.handlebars', Rasputin::HandlebarsTemplate
-      app.assets.register_engine '.hbs', Rasputin::HandlebarsTemplate
+    config.assets.configure do |env|
+      env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
+      env.register_engine '.handlebars', Rasputin::HandlebarsTemplate
+      env.register_engine '.hbs', Rasputin::HandlebarsTemplate
     end
   end
 end

--- a/lib/rasputin.rb
+++ b/lib/rasputin.rb
@@ -21,7 +21,7 @@ module Rasputin
 
     config.assets.configure do |env|
       silence_warning = !Sprockets::VERSION.start_with?("4")
-      env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
+      env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor, silence_deprecation: silence_warning
       env.register_engine '.handlebars', Rasputin::HandlebarsTemplate, silence_deprecation: silence_warning
       env.register_engine '.hbs', Rasputin::HandlebarsTemplate, silence_deprecation: silence_warning
     end

--- a/lib/rasputin.rb
+++ b/lib/rasputin.rb
@@ -20,9 +20,10 @@ module Rasputin
     config.rasputin.strip_javascript_require = true
 
     config.assets.configure do |env|
+      deprecation_warning = Sprockets::VERSION.start_with?("4")
       env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
-      env.register_engine '.handlebars', Rasputin::HandlebarsTemplate
-      env.register_engine '.hbs', Rasputin::HandlebarsTemplate
+      env.register_engine '.handlebars', Rasputin::HandlebarsTemplate, silence_deprecation: deprecation_warning
+      env.register_engine '.hbs', Rasputin::HandlebarsTemplate, silence_deprecation: deprecation_warning
     end
   end
 end

--- a/lib/rasputin.rb
+++ b/lib/rasputin.rb
@@ -21,7 +21,7 @@ module Rasputin
 
     config.assets.configure do |env|
       silence_warning = !Sprockets::VERSION.start_with?("4")
-      env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor, silence_deprecation: silence_warning
+      env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
       env.register_engine '.handlebars', Rasputin::HandlebarsTemplate, silence_deprecation: silence_warning
       env.register_engine '.hbs', Rasputin::HandlebarsTemplate, silence_deprecation: silence_warning
     end

--- a/lib/rasputin.rb
+++ b/lib/rasputin.rb
@@ -20,10 +20,10 @@ module Rasputin
     config.rasputin.strip_javascript_require = true
 
     config.assets.configure do |env|
-      deprecation_warning = Sprockets::VERSION.start_with?("4")
+      silence_warning = !Sprockets::VERSION.start_with?("4")
       env.register_preprocessor 'application/javascript', Rasputin::RequirePreprocessor
-      env.register_engine '.handlebars', Rasputin::HandlebarsTemplate, silence_deprecation: deprecation_warning
-      env.register_engine '.hbs', Rasputin::HandlebarsTemplate, silence_deprecation: deprecation_warning
+      env.register_engine '.handlebars', Rasputin::HandlebarsTemplate, silence_deprecation: silence_warning
+      env.register_engine '.hbs', Rasputin::HandlebarsTemplate, silence_deprecation: silence_warning
     end
   end
 end

--- a/rasputin.gemspec
+++ b/rasputin.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.description = %q{Ember.js for the Rails asset pipeline.}
 
   s.rubyforge_project = "rasputin"
-  s.add_runtime_dependency 'railties', '~> 4.2'
-  s.add_runtime_dependency 'actionpack', '~> 4.2'
-  s.add_runtime_dependency 'sprockets', '~> 2.2'
+  s.add_runtime_dependency 'railties', '>= 3.1', '< 5.2'
+  s.add_runtime_dependency 'actionpack', '>= 3.1', '< 5.2'
+  s.add_runtime_dependency 'sprockets'
   s.add_runtime_dependency 'jquery-rails'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
LeanKit card: https://emexpower.leankit.com/card/514446086

Related PRs:
- https://github.com/emex/supplier_portal/pull/180
- https://github.com/emex/portal_chef/pull/5
- https://github.com/emex/rasputin/pull/3

If jumping to 5.x proves to be too time-consuming, we can jump to the latest 4.x instead.

We'll need a manual QA pass as part of this.

This card will pave the way for spiking out the use of webpacker on the Portal.